### PR TITLE
Teasing apart metrics for queue size:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .gradle
+/bin/

--- a/src/main/java/com/monetate/koupler/KinesisEventProducer.java
+++ b/src/main/java/com/monetate/koupler/KinesisEventProducer.java
@@ -58,10 +58,14 @@ public class KinesisEventProducer implements Runnable {
         this.queue.add(event);
     }
     
-    public int getQueueSize(){
+    public int getInternalQueueSize(){
         return this.queue.size();
     }
-    
+
+    public int getKplQueueSize(){
+        return this.producer.getOutstandingRecordsCount();
+    }
+
     public void clearQueue(){
         this.queue.clear();
     }

--- a/src/main/java/com/monetate/koupler/KouplerMetrics.java
+++ b/src/main/java/com/monetate/koupler/KouplerMetrics.java
@@ -96,7 +96,6 @@ public class KouplerMetrics implements Runnable {
                     .withDimensions(hostDimension)
                     .withMetricName("InternalEventQueueCount")
                     .withValue(producer.getInternalQueueSize() * 1.0);
-
             
             MetricDatum queuedEventsPerSecond = new MetricDatum()
                     .withDimensions(hostDimension)

--- a/src/main/java/com/monetate/koupler/KouplerMetrics.java
+++ b/src/main/java/com/monetate/koupler/KouplerMetrics.java
@@ -87,11 +87,17 @@ public class KouplerMetrics implements Runnable {
                     .withMetricName("BytesPerEvent")
                     .withValue(bytesHistogram.getSnapshot().getMean());
 
-            MetricDatum eventQueueCount = new MetricDatum()
+            MetricDatum kplEventQueueCount = new MetricDatum()
                     .withDimensions(hostDimension)
-                    .withMetricName("EventQueueCount")
-                    .withValue(producer.getQueueSize() * 1.0);
+                    .withMetricName("KplEventQueueCount")
+                    .withValue(producer.getKplQueueSize() * 1.0);
 
+            MetricDatum internalEventQueueCount = new MetricDatum()
+                    .withDimensions(hostDimension)
+                    .withMetricName("InternalEventQueueCount")
+                    .withValue(producer.getInternalQueueSize() * 1.0);
+
+            
             MetricDatum queuedEventsPerSecond = new MetricDatum()
                     .withDimensions(hostDimension)
                     .withMetricName("QueuedEventsPerSecond")
@@ -103,7 +109,8 @@ public class KouplerMetrics implements Runnable {
                     .withValue(completedMeter.getMeanRate());
 
             cloudWatch.putMetricData(new PutMetricDataRequest().withMetricData(bytesPerEvent).withNamespace(appName));
-            cloudWatch.putMetricData(new PutMetricDataRequest().withMetricData(eventQueueCount).withNamespace(appName));
+            cloudWatch.putMetricData(new PutMetricDataRequest().withMetricData(kplEventQueueCount).withNamespace(appName));
+            cloudWatch.putMetricData(new PutMetricDataRequest().withMetricData(internalEventQueueCount).withNamespace(appName));
             cloudWatch.putMetricData(new PutMetricDataRequest().withMetricData(queuedEventsPerSecond).withNamespace(appName));
             cloudWatch.putMetricData(new PutMetricDataRequest().withMetricData(completedEventsPerSecond).withNamespace(appName));
             


### PR DESCRIPTION
- one for internal queuing (between socket/pipe read(s) and processing)
- one for KPL queue in native process