### PR TITLE
Metric Error Log

### DIFF
--- a/src/main/java/com/monetate/koupler/KouplerMetrics.java
+++ b/src/main/java/com/monetate/koupler/KouplerMetrics.java
@@ -116,7 +116,7 @@ public class KouplerMetrics implements Runnable {
             LOGGER.debug("Published metrics to CloudWatch [{}].", this.toString());
 
         } catch (Exception e) {
-            LOGGER.error("Problem posting metrics to cloudwatch.", e);
+            LOGGER.error("Problem posting or reading cloudwatch metrics.", e);
         }
     }
 }


### PR DESCRIPTION
### What

Update the error log message when there is an issue dealing with Cloudwatch.

### Why

Looks like `MetricDatum` does a read operation in Cloudwatch. The previous error message fails to indicate that there is a read permission missing. 