### PR TITLE
Improving release mojo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     compile group: 'org.eclipse.jetty', name: 'jetty-http', version:'9.0.2.v20130417'
 }
 
-task copyRuntimeLibs(type: Copy) {
+task copyRuntimeLibs(dependsOn: 'build', type: Copy) {
     from configurations.runtime
     into 'build/libs'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ targetCompatibility = 1.8
 
 release {
     versionPropertyFile = 'gradle.properties'
-    buildTasks = ['build', 'copyRuntimeLibs', 'batchZip']
+    buildTasks = ['build', 'dist']
     scmAdapters = [
         net.researchgate.release.GitAdapter
     ]
@@ -64,7 +64,7 @@ task copyRuntimeLibs(type: Copy) {
     into 'build/libs'
 }
 
-task batchZip(type: Zip) {
+task zipDistribution(dependsOn: 'copyRuntimeLibs', type: Zip) {
     into("koupler-${version}") {
         from 'LICENSE.txt'
         from 'README.md'
@@ -81,3 +81,14 @@ task batchZip(type: Zip) {
         }
     }
 }
+
+task dist (dependsOn: 'zipDistribution', type: Copy){
+    from 'build/distributions/'
+    include '*.zip'
+    into 'releases'
+}
+
+clean{
+    delete "target"
+}
+


### PR DESCRIPTION
The tasks in the build were not connected, which means we would/could release w/o re-building all the artifacts.  This pull request properly articulates the dependencies between the tasks so that can no longer happen.