### PR TITLE
adjust location of libs for CLASSPATH

### DIFF
--- a/sh/koupler.sh
+++ b/sh/koupler.sh
@@ -3,7 +3,7 @@
 BASEDIR=$(dirname $0)
 
 CLASSPATH=
-for i in `ls ./lib/*.jar`
+for i in `ls build/libs/*.jar`
 do
   CLASSPATH=${CLASSPATH}:${i}
 done


### PR DESCRIPTION
Allows the following to work from root of source tree:

        ./sh/koupler.sh ...



