### PR TITLE
Adding JSON format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-build
+/build
+/releases
 .gradle
 /bin/
 .idea
 .settings
 .project
 .classpath
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You should see the following:
    usage: java -jar koupler*.jar
     -delimiter <arg>          delimiter between fields (default: ',')
     -partitionKeyField <arg>  zero-based index of field containing partition key (default: 0)
+    -format <arg>             format for which partitionKey will be extracted (default: split)
     -pipe                     pipe mode
     -port <arg>               listening port (default: 4242)
     -propertiesFile <arg>     kpl properties file (default: ./conf/kpl.properties)

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     compile group: 'org.eclipse.jetty', name: 'jetty-util', version:'9.0.2.v20130417'
     compile group: 'org.eclipse.jetty', name: 'jetty-io', version:'9.0.2.v20130417'
     compile group: 'org.eclipse.jetty', name: 'jetty-http', version:'9.0.2.v20130417'
+    compile group: 'com.jayway.jsonpath', name: 'json-path', version:'2.2.0'
 }
 
 task copyRuntimeLibs(dependsOn: 'build', type: Copy) {

--- a/src/main/java/com/monetate/koupler/Koupler.java
+++ b/src/main/java/com/monetate/koupler/Koupler.java
@@ -173,7 +173,7 @@ public abstract class Koupler implements Runnable {
 
         String format = "split";
         if (cmd.hasOption("format")) {
-            appName = cmd.getOptionValue("format");
+            format = cmd.getOptionValue("format");
         }
 
         KinesisEventProducer producer = new KinesisEventProducer(format, cmd, propertiesFile, streamName, queueSize, appName);

--- a/src/main/java/com/monetate/koupler/format/FormatFactory.java
+++ b/src/main/java/com/monetate/koupler/format/FormatFactory.java
@@ -9,6 +9,8 @@ public class FormatFactory {
     public static Format getFormat(String format, CommandLine cmd){
         if (format.equals("split")){
             return new SplitFormat(cmd);
+        } else if (format.equals("json")) {
+            return new JsonFormat();
         } else {
             String msg = String.format("Incompatible format specified for event. [%s]", format);
             throw new RuntimeException(msg);

--- a/src/main/java/com/monetate/koupler/format/JsonFormat.java
+++ b/src/main/java/com/monetate/koupler/format/JsonFormat.java
@@ -1,0 +1,19 @@
+package com.monetate.koupler.format;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+
+/**
+ * Created by jpalladino on 8/20/16.
+ */
+public class JsonFormat implements Format {
+
+    @Override
+    public String getPartitionKey(String event) {
+        Object jsonEvent = Configuration.defaultConfiguration().jsonProvider().parse(event);
+        return JsonPath.read(jsonEvent, "$.partitionKey");
+    }
+
+    @Override
+    public String getData(String event) { return event; }
+}


### PR DESCRIPTION
## What
- Adding `json` format in addition to `split`

## Why
Based off this [conversation](https://github.com/monetate/koupler/issues/26#issuecomment-215565877)

Assumes the event is a `json` blob, you can add a `partition_key` field and use the `-format json` flag to extract it out. 
