### PR TITLE
Make partitionKey field configurable from the command line

### DIFF
--- a/src/main/java/com/monetate/koupler/format/FormatFactory.java
+++ b/src/main/java/com/monetate/koupler/format/FormatFactory.java
@@ -10,7 +10,7 @@ public class FormatFactory {
         if (format.equals("split")){
             return new SplitFormat(cmd);
         } else if (format.equals("json")) {
-            return new JsonFormat();
+            return new JsonFormat(cmd);
         } else {
             String msg = String.format("Incompatible format specified for event. [%s]", format);
             throw new RuntimeException(msg);

--- a/src/main/java/com/monetate/koupler/format/JsonFormat.java
+++ b/src/main/java/com/monetate/koupler/format/JsonFormat.java
@@ -2,16 +2,25 @@ package com.monetate.koupler.format;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
+import org.apache.commons.cli.CommandLine;
 
 /**
  * Created by jpalladino on 8/20/16.
  */
 public class JsonFormat implements Format {
 
+    private String partitionKeyField;
+
+    public JsonFormat(CommandLine cmd) {
+        if (cmd.hasOption("partitionKeyField")) {
+            partitionKeyField = cmd.getOptionValue("partitionKeyField");
+        }
+    }
+
     @Override
     public String getPartitionKey(String event) {
         Object jsonEvent = Configuration.defaultConfiguration().jsonProvider().parse(event);
-        return JsonPath.read(jsonEvent, "$.partitionKey");
+        return JsonPath.read(jsonEvent, partitionKeyField);
     }
 
     @Override


### PR DESCRIPTION
## What
- add `partitionKeyField` arg to `JsonFormat`
- use `partitionKeyField` to tease out the JsonPath of where the `partitionKey` is within the payload

## Why
This makes the partition key configurable so that users are not limited to the name of the field or where it lives in the json payload. 

```
koupler.sh -partitionKeyField '$.partitionKey' -format 'json'
```