### PR TITLE
Reduce reporting frequency, increase period from 30s to 60s.

### DIFF
--- a/src/main/java/com/monetate/koupler/KinesisEventProducer.java
+++ b/src/main/java/com/monetate/koupler/KinesisEventProducer.java
@@ -74,7 +74,7 @@ public class KinesisEventProducer implements Runnable {
     }
     
     public void startMetrics(){
-    	this.metrics.start(30);
+        this.metrics.start(60);
     }
 
     public String getPartitionKey(String event) {


### PR DESCRIPTION
### Why?

Save cloudwatch putmetric calls, cloudwatch only reports at 1m granularity.

### What?

Report every 60s instead of 30s.