### PR TITLE
Reduce default metrics granularity from shard to stream.

### DIFF
--- a/conf/kpl.properties
+++ b/conf/kpl.properties
@@ -140,7 +140,7 @@ MaxConnections = 16
 #
 # Default: shard
 # Expected pattern: global|stream|shard
-MetricsGranularity = shard
+MetricsGranularity = stream
 
 # Controls the number of metrics that are uploaded to CloudWatch.
 #


### PR DESCRIPTION
### Why?

Reduce CloudWatch PutMetricsData calls.