### PR TITLE
Reduce KPL MetricsLevel to summary.

### DIFF
--- a/conf/kpl.properties
+++ b/conf/kpl.properties
@@ -155,7 +155,7 @@ MetricsGranularity = stream
 #
 # Default: detailed
 # Expected pattern: none|summary|detailed
-MetricsLevel = detailed
+MetricsLevel = summary
 
 # The namespace to upload metrics under.
 #


### PR DESCRIPTION
### Why?

Save CloudWatch costs.