### PR TITLE
TcpKoupler - allow unicode when reading off inputstream

### DIFF
--- a/src/main/java/com/monetate/koupler/TcpKoupler.java
+++ b/src/main/java/com/monetate/koupler/TcpKoupler.java
@@ -48,7 +48,7 @@ public class TcpKoupler extends Koupler implements Runnable {
             while (true) {
                 Socket socket = listener.accept();
                 LOGGER.info("Accepting new socket [{}].", socket);
-                BufferedReader data = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+                BufferedReader data = new BufferedReader(new InputStreamReader(socket.getInputStream(), "UTF-8"));
                 Future<Integer> future = this.getThreadPool()
                         .submit(new KouplerThread(data, new TcpExceptionHandler(socket)));
             }


### PR DESCRIPTION
## What
- explicitly set the charset for the `InputStreamReader`

## Why
The current implementation was reading in as `ASCII`
```
* An InputStreamReader is a bridge from byte streams to character streams: It
* reads bytes and decodes them into characters using a specified {@link
* java.nio.charset.Charset charset}.  The charset that it uses
* may be specified by name or may be given explicitly, or the platform's
* default charset may be accepted.```