### PR TITLE
print invalid event to log file when unable to extract partition key

### DIFF
--- a/src/main/java/com/monetate/koupler/KinesisEventProducer.java
+++ b/src/main/java/com/monetate/koupler/KinesisEventProducer.java
@@ -81,7 +81,7 @@ public class KinesisEventProducer implements Runnable {
         try {
             return format.getPartitionKey(event);
         } catch (Exception e) {
-            LOGGER.warn("Received event from which we could NOT extract partition key.", e);
+            LOGGER.warn("Received event from which we could NOT extract partition key: " + event, e);
             return null;
         }
     }


### PR DESCRIPTION
 # What
print invalid event to log file when unable to extract partition key

 # Why
Aid in diagnosis