### PR TITLE
Update log4j2 version to mitigate vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,9 +34,9 @@ configurations {
 
 dependencies {
     compile group: 'com.google.guava', name:'guava', version:'18.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version:'2.3'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.3'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version:'2.3'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version:'2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version:'2.15.0'
     compile group: 'com.amazonaws', name: 'amazon-kinesis-client', version:'1.8.10'
     compile group: 'com.amazonaws', name: 'amazon-kinesis-producer', version:'0.12.8'
     compile group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version:'1.11.245'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.4.4
+version=0.4.5

--- a/monetate.build.gradle
+++ b/monetate.build.gradle
@@ -27,9 +27,9 @@ repositories {
 
 dependencies {
     compile group: 'com.google.guava', name:'guava', version:'18.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version:'2.3'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.3'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version:'2.3'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version:'2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version:'2.15.0'
     compile group: 'com.amazonaws', name: 'amazon-kinesis-client', version:'1.5.1'
     compile group: 'com.amazonaws', name: 'amazon-kinesis-producer', version:'0.10.1'
     compile group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version:'1.9.37'


### PR DESCRIPTION
Update version of log4j2 to mitigate https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228